### PR TITLE
fix(errors): normalize error logging and responses

### DIFF
--- a/src/middleware/error.middleware.js
+++ b/src/middleware/error.middleware.js
@@ -1,7 +1,32 @@
 import { logger } from '#src/core/logger.js';
-import { errorHandler as handleError } from '#src/utils/errors/error-handler.js';
+import {
+  errorHandler as handleError,
+  normalizeToAppError,
+} from '#src/utils/errors/error-handler.js';
 
 export const errorHandler = (err, req, res, next) => {
-  logger.error('Request error:', { method: req.method, url: req.url, err });
-  handleError(res, err);
+  const appError = normalizeToAppError(err);
+
+  logger.error('Request error:', {
+    method: req.method,
+    url: req.url,
+    raw: {
+      name: err?.name ?? 'UnknownError',
+      message: err?.message ?? 'Unexpected error',
+      code: err?.code ?? null,
+      statusCode: err?.statusCode ?? null,
+      details: err?.details ?? null,
+      expiredAt: err?.expiredAt ?? null,
+      stack: err?.stack ?? null,
+    },
+    normalized: {
+      debug: appError.debug,
+      statusCode: appError.statusCode,
+      type: appError.type,
+      message: appError.message,
+      details: appError.details ?? null,
+    },
+  });
+
+  handleError(res, appError);
 };

--- a/src/utils/errors/error-handler.js
+++ b/src/utils/errors/error-handler.js
@@ -3,7 +3,7 @@ import { ERROR_MESSAGES } from '#src/constants/error-messages.js';
 import { AppError } from '#src/utils/errors/app-error.js';
 import { getPrismaTargetFields } from '#src/utils/prisma/get-prisma-target-fields.js';
 
-const normalizeToAppError = (error) => {
+export const normalizeToAppError = (error) => {
   if (error instanceof AppError) {
     return error;
   }


### PR DESCRIPTION
- export shared error normalization logic from the error handler
- log both raw and normalized error payloads in the error middleware
- keep client responses aligned with the normalized app error model
- preserve low-level error context such as stack traces and token expiration details in server logs