### PR TITLE
feat(catalog): add genre catalog and free checkout flow

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -14,6 +14,7 @@ import { ordersRouter } from './modules/orders/index.js';
 import { libraryRouter } from './modules/library/index.js';
 import { reviewsRouter } from './modules/reviews/index.js';
 import { tagsRouter } from './modules/tags/index.js';
+import { catalogRouter } from './modules/catalog/index.js';
 import cookieParser from 'cookie-parser';
 import '#src/modules/Auth/config/passport.js';
 
@@ -43,6 +44,7 @@ app.use('/api', ordersRouter);
 app.use('/api', libraryRouter);
 app.use('/api', reviewsRouter);
 app.use('/api', tagsRouter);
+app.use('/api', catalogRouter);
 
 app.get('/', async (_, res) => {
   logger.info('GET / - Homepage request');

--- a/src/modules/catalog/controllers/catalog.controller.js
+++ b/src/modules/catalog/controllers/catalog.controller.js
@@ -1,0 +1,13 @@
+import { HTTP_STATUS } from '#src/constants/http-statuses.js';
+import { logger } from '#src/core/logger.js';
+import { listCatalogGenres } from '../services/catalog.service.js';
+
+export const handleListCatalogGenres = async (_, res) => {
+  logger.info('GET /api/catalog/genres - List catalog genres');
+
+  const genres = await listCatalogGenres();
+
+  return res.status(HTTP_STATUS.OK).json({
+    data: genres,
+  });
+};

--- a/src/modules/catalog/index.js
+++ b/src/modules/catalog/index.js
@@ -1,0 +1,3 @@
+import { catalogRouter } from './routes/catalog.routes.js';
+
+export { catalogRouter };

--- a/src/modules/catalog/mappers/catalog.mapper.js
+++ b/src/modules/catalog/mappers/catalog.mapper.js
@@ -1,0 +1,20 @@
+const findGenreCover = (genre) => {
+  const gameWithImage = genre.game_tags.find((gameTag) => gameTag.games?.game_images?.length > 0);
+  const image = gameWithImage?.games?.game_images?.[0];
+
+  if (!image) {
+    return null;
+  }
+
+  return {
+    url: image.url,
+    alt: image.alt,
+  };
+};
+
+export const formatCatalogGenre = (genre) => ({
+  id: genre.id,
+  name: genre.name,
+  games_count: genre._count?.game_tags ?? 0,
+  cover: findGenreCover(genre),
+});

--- a/src/modules/catalog/repositories/catalog.repository.js
+++ b/src/modules/catalog/repositories/catalog.repository.js
@@ -1,0 +1,44 @@
+import { prisma } from '#src/core/prisma.js';
+
+export const findCatalogTagTypesRecord = async (db = prisma) => {
+  return db.tag_types.findMany({
+    select: {
+      id: true,
+      name: true,
+    },
+  });
+};
+
+export const findCatalogGenreRecords = async ({ typeIds }, db = prisma) => {
+  return db.tags.findMany({
+    where: {
+      type_id: {
+        in: typeIds,
+      },
+    },
+    include: {
+      _count: {
+        select: {
+          game_tags: true,
+        },
+      },
+      game_tags: {
+        orderBy: [{ game_id: 'asc' }, { id: 'asc' }],
+        include: {
+          games: {
+            include: {
+              game_images: {
+                select: {
+                  url: true,
+                  alt: true,
+                },
+                orderBy: [{ sort_order: 'asc' }, { id: 'asc' }],
+                take: 1,
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+};

--- a/src/modules/catalog/routes/catalog.routes.js
+++ b/src/modules/catalog/routes/catalog.routes.js
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { handleListCatalogGenres } from '../controllers/catalog.controller.js';
+
+const catalogRouter = Router();
+
+catalogRouter.get('/catalog/genres', handleListCatalogGenres);
+
+export { catalogRouter };

--- a/src/modules/catalog/services/catalog.service.js
+++ b/src/modules/catalog/services/catalog.service.js
@@ -1,0 +1,36 @@
+import { formatCatalogGenre } from '../mappers/catalog.mapper.js';
+import {
+  findCatalogGenreRecords,
+  findCatalogTagTypesRecord,
+} from '../repositories/catalog.repository.js';
+
+const GENRE_TYPE_ALIASES = new Set(['genre', 'genres']);
+
+const normalizeTagTypeName = (value) =>
+  String(value)
+    .trim()
+    .toLowerCase()
+    .replace(/[-\s]+/g, '_');
+
+const isGenreTagType = (tagType) => GENRE_TYPE_ALIASES.has(normalizeTagTypeName(tagType.name));
+
+export const listCatalogGenres = async () => {
+  const tagTypes = await findCatalogTagTypesRecord();
+  const genreTypeIds = tagTypes.filter(isGenreTagType).map((tagType) => tagType.id);
+
+  if (genreTypeIds.length === 0) {
+    return [];
+  }
+
+  const genres = await findCatalogGenreRecords({ typeIds: genreTypeIds });
+
+  return genres.map(formatCatalogGenre).sort((left, right) => {
+    const countDiff = right.games_count - left.games_count;
+
+    if (countDiff !== 0) {
+      return countDiff;
+    }
+
+    return left.name.localeCompare(right.name);
+  });
+};

--- a/src/modules/payments/repositories/payments.repository.js
+++ b/src/modules/payments/repositories/payments.repository.js
@@ -157,13 +157,18 @@ export const cancelOrdersWithPaymentsRecord = async ({ orderIds }, db = prisma) 
   };
 };
 
-export const createOrderRecord = async ({ userId, source, currency, totalAmount }, db = prisma) => {
+export const createOrderRecord = async (
+  { userId, source, currency, totalAmount, status, paidAt },
+  db = prisma,
+) => {
   return db.orders.create({
     data: {
       user_id: userId,
       source,
       currency,
       total_amount: totalAmount,
+      ...(status === undefined ? {} : { status }),
+      ...(paidAt === undefined ? {} : { paid_at: paidAt }),
       updated_at: new Date(),
     },
   });
@@ -177,6 +182,17 @@ export const createOrderItemsRecord = async ({ orderId, items }, db = prisma) =>
       title_snapshot: item.titleSnapshot,
       price_snapshot: item.priceSnapshot,
     })),
+  });
+};
+
+export const findOrderItemsByOrderIdRecord = async ({ orderId }, db = prisma) => {
+  return db.order_items.findMany({
+    where: {
+      order_id: orderId,
+    },
+    orderBy: {
+      id: 'asc',
+    },
   });
 };
 

--- a/src/modules/payments/services/payments.service.js
+++ b/src/modules/payments/services/payments.service.js
@@ -19,6 +19,7 @@ import {
   findLibraryByUserIdRecord,
   findLibraryGameIdsByUserIdRecord,
   findOrderByIdAndUserIdRecord,
+  findOrderItemsByOrderIdRecord,
   findOrdersByUserIdRecord,
   findPaymentByExternalPaymentIdRecord,
   findWaitingOrdersByUserAndGameIdsRecord,
@@ -395,8 +396,6 @@ export const createCheckoutPayment = async ({ userId, body }) => {
     });
   }
 
-  getYooKassaConfig();
-
   const gameIds = parseCheckoutGameIds(parsed.data);
   const source = 'basket';
 
@@ -422,6 +421,7 @@ export const createCheckoutPayment = async ({ userId, body }) => {
     );
 
     const totalAmount = buildCheckoutAmount(games);
+    const paidAt = totalAmount.equals(0) ? new Date() : null;
 
     const order = await createOrderRecord(
       {
@@ -429,6 +429,7 @@ export const createCheckoutPayment = async ({ userId, body }) => {
         source,
         currency: 'RUB',
         totalAmount: totalAmount.toFixed(2),
+        ...(paidAt === null ? {} : { status: 'paid', paidAt }),
       },
       tx,
     );
@@ -444,6 +445,36 @@ export const createCheckoutPayment = async ({ userId, body }) => {
       },
       tx,
     );
+
+    if (paidAt !== null) {
+      const orderItems = await findOrderItemsByOrderIdRecord({ orderId: order.id }, tx);
+
+      await createUserGamesRecord(
+        {
+          userId,
+          orderItems,
+        },
+        tx,
+      );
+
+      await deleteBasketItemsByUserAndGameIdsRecord(
+        {
+          userId,
+          gameIds,
+        },
+        tx,
+      );
+
+      return {
+        orderId: order.id,
+        paymentId: null,
+        externalPaymentId: null,
+        status: 'succeeded',
+        confirmationUrl: null,
+        amount: totalAmount.toFixed(2),
+        currency: 'RUB',
+      };
+    }
 
     const payment = await createPaymentRecord(
       {
@@ -462,7 +493,13 @@ export const createCheckoutPayment = async ({ userId, body }) => {
     };
   });
 
+  if (draftOrder.paymentId === null) {
+    return draftOrder;
+  }
+
   try {
+    getYooKassaConfig();
+
     const { payment, idempotenceKey } = await createYooKassaPayment({
       orderId: draftOrder.orderId,
       paymentId: draftOrder.paymentId,

--- a/src/server.js
+++ b/src/server.js
@@ -4,6 +4,8 @@ import { prisma } from '#src/core/prisma.js';
 import { logger } from '#src/core/logger.js';
 
 const PORT = process.env.PORT || 5000;
+const HOST = process.env.HOST || '0.0.0.0';
+const LAN_IP = process.env.LAN_IP || 'localhost';
 let server = null;
 
 const reset = '\x1b[0m';
@@ -27,8 +29,9 @@ const start = async () => {
     await prisma.$connect();
     logger.success('Database connected');
 
-    server = app.listen(PORT, () => {
+    server = app.listen(PORT, HOST, () => {
       logger.success(`Server running on port ${blue}http://localhost:${bold}${PORT}${reset}`);
+      logger.success(`LAN access: ${blue}http://${LAN_IP}:${bold}${PORT}${reset}`);
     });
   } catch (err) {
     logger.error('Startup failed: database unavailable', err);


### PR DESCRIPTION
## Summary
- add a catalog genres endpoint with game counts and cover images
- register the catalog router under the API routes
- support zero-amount checkout by marking orders as paid without creating a YooKassa payment
- grant free games to the user library and remove them from the basket during checkout
- bind the server to a configurable host and log LAN access URL